### PR TITLE
Added palette callback function

### DIFF
--- a/src/GifDecoder.h
+++ b/src/GifDecoder.h
@@ -23,6 +23,13 @@
 #define ERROR_GIF_DECODE_ERROR          -10
 #define ERROR_MISSING_CALLBACK_FUNCTION -11
 
+
+typedef struct rgb_24 {
+  uint8_t red;
+  uint8_t green;
+  uint8_t blue;
+} rgb_24;
+
 typedef void (*callback)(void);
 typedef void (*pixel_callback)(int16_t x, int16_t y, uint8_t red, uint8_t green,
                                uint8_t blue);
@@ -30,17 +37,14 @@ typedef void (*line_callback)(int16_t x, int16_t y, uint8_t *buf, int16_t wid,
                               uint16_t *palette565, int16_t skip);
 typedef void *(*get_buffer_callback)(void);
 
+typedef void (*palette_callback)(rgb_24 *palette888, bool isGlobalPalette);
+
 typedef bool (*file_seek_callback)(unsigned long position);
 typedef unsigned long (*file_position_callback)(void);
 typedef int (*file_read_callback)(void);
 typedef int (*file_read_block_callback)(void *buffer, int numberOfBytes);
 typedef int (*file_size_callback)(void);
 
-typedef struct rgb_24 {
-  uint8_t red;
-  uint8_t green;
-  uint8_t blue;
-} rgb_24;
 
 template <int maxGifWidth, int maxGifHeight, int lzwMaxBits, bool useMalloc=false> class GifDecoder {
 public:
@@ -63,6 +67,8 @@ public:
   void setDrawPixelCallback(pixel_callback f);
   void setDrawLineCallback(line_callback f); // note this callback is not currently used, but may be used in the future
   void setStartDrawingCallback(callback f); // note this callback is not currently used
+
+  void setPaletteCallback(palette_callback);
 
   void setFileSeekCallback(file_seek_callback f);
   void setFilePositionCallback(file_position_callback f);
@@ -98,6 +104,7 @@ private:
   static file_read_callback fileReadCallback;
   static file_read_block_callback fileReadBlockCallback;
   static file_size_callback fileSizeCallback;
+  static palette_callback paletteCallback;
 
   static void GIFDraw(GIFDRAW *pDraw);
   static void * GIFOpenFile(const char *fname, int32_t *pSize);

--- a/src/GifDecoder_Impl.h
+++ b/src/GifDecoder_Impl.h
@@ -156,7 +156,7 @@ void GifDecoder<maxGifWidth, maxGifHeight, lzwMaxBits, useMalloc>::GIFDraw(GIFDR
   usPalette = (rgb_24*)pDraw->pPalette;
 
     if(paletteCallback)
-        paletteCallback(usPalette,pDraw->bIsGlobalPalette);
+        paletteCallback(usPalette,pDraw->ucIsGlobalPalette==1);
 
   y = pDraw->iY + pDraw->y; // current line
   

--- a/src/GifDecoder_Impl.h
+++ b/src/GifDecoder_Impl.h
@@ -53,6 +53,8 @@ template <int maxGifWidth, int maxGifHeight, int lzwMaxBits, bool useMalloc>
 file_read_block_callback GifDecoder<maxGifWidth, maxGifHeight, lzwMaxBits, useMalloc>::fileReadBlockCallback;
 template <int maxGifWidth, int maxGifHeight, int lzwMaxBits, bool useMalloc>
 file_size_callback GifDecoder<maxGifWidth, maxGifHeight, lzwMaxBits, useMalloc>::fileSizeCallback;
+template <int maxGifWidth, int maxGifHeight, int lzwMaxBits, bool useMalloc>
+palette_callback GifDecoder<maxGifWidth, maxGifHeight, lzwMaxBits, useMalloc>::paletteCallback;
 
 
 template <int maxGifWidth, int maxGifHeight, int lzwMaxBits, bool useMalloc>
@@ -123,6 +125,12 @@ void GifDecoder<maxGifWidth, maxGifHeight, lzwMaxBits, useMalloc>::setFileReadBl
 }
 
 template <int maxGifWidth, int maxGifHeight, int lzwMaxBits, bool useMalloc>
+void GifDecoder<maxGifWidth, maxGifHeight, lzwMaxBits, useMalloc>::setPaletteCallback(palette_callback f) {
+  paletteCallback = f;
+}
+
+
+template <int maxGifWidth, int maxGifHeight, int lzwMaxBits, bool useMalloc>
 void GifDecoder<maxGifWidth, maxGifHeight, lzwMaxBits, useMalloc>::DrawPixelRow(int startX, int y, int numPixels, rgb_24 * data) {
   for(int i=0; i<numPixels; i++)
   {
@@ -146,6 +154,9 @@ void GifDecoder<maxGifWidth, maxGifHeight, lzwMaxBits, useMalloc>::GIFDraw(GIFDR
   if (iWidth > DISPLAY_WIDTH)
     iWidth = DISPLAY_WIDTH;
   usPalette = (rgb_24*)pDraw->pPalette;
+
+    if(paletteCallback)
+        paletteCallback(usPalette,pDraw->bIsGlobalPalette);
 
   y = pDraw->iY + pDraw->y; // current line
   


### PR DESCRIPTION
Hi,

I've been using this library for some time now, and it works very well.

However, I have an application that requires the palette to be manipulated every now and again. In order to achieve this, I've added a callback that is called during the draw callback function with the palette information. This callback allows the user to manipulate the palette before drawing it. The user can, for example, change the hue of the image without having to do so for each pixel individually. 

I've had this working rather well in my application (some nice effects!). It does rely on a change in the AnimatedGIF library, as it needs information on whether it is global or local palette that's being passed. I've got a pull request on that library to do exactly this (https://github.com/bitbank2/AnimatedGIF/pull/59#issue-1335027242).

I hope you find this change useful.

Cheers,
welshcoder