### PR TITLE
Fix crashes caused by uninitialized beginCalled

### DIFF
--- a/src/GifDecoder.h
+++ b/src/GifDecoder.h
@@ -74,7 +74,7 @@ private:
   AnimatedGIF * gif;
   uint8_t buffer[useMalloc ? 0 : sizeof(AnimatedGIF)];
 
-  bool beginCalled;
+  bool beginCalled = false;
   bool usingFileCallbacks = true;
 
   uint8_t *gifPData;


### PR DESCRIPTION
This initializes `GifDecoder::beginCalled` to `false`, to prevent storeProhibited panics that can occur further down the line due to the call to `AnimatedGIF::begin()` not taking place. 

A discussion of the crashes caused by the bug this PR fixes can be found from [this comment](https://github.com/PlummersSoftwareLLC/NightDriverStrip/issues/547#issuecomment-1831564571) on https://github.com/PlummersSoftwareLLC/NightDriverStrip/issues/547 onwards, as well as the PRs that the comments in that discussion link to.